### PR TITLE
Fix apikey handling

### DIFF
--- a/net/browserless_agent/src/browserless_agent.ts
+++ b/net/browserless_agent/src/browserless_agent.ts
@@ -21,6 +21,17 @@ type BrowserlessResult =
       };
     };
 
+
+const getBrowserlessToken = (params: BrowserlessParams, config?: DefaultConfigData) => {
+  if (params?.apiKey) {
+    return params.apiKey;
+  }
+  if (config?.apiKey) {
+    return config.apiKey;
+  }
+  return typeof process !== "undefined" ? process?.env?.BROWSERLESS_API_TOKEN : null;
+};
+
 export const browserlessAgent: AgentFunction<BrowserlessParams, BrowserlessResult, BrowserlessInputs, DefaultConfigData> = async ({
   namedInputs,
   params,
@@ -31,8 +42,7 @@ export const browserlessAgent: AgentFunction<BrowserlessParams, BrowserlessResul
 
   const throwError = params?.throwError ?? false;
 
-  const browserlessToken =
-    params?.apiKey ?? (typeof config !== "undefined" && config.apiKey) ?? ((typeof process !== "undefined" && process?.env?.BROWSERLESS_API_TOKEN) || null);
+  const browserlessToken = getBrowserlessToken(params, config);
 
   // Check if API token is provided
   if (!browserlessToken) {

--- a/net/browserless_agent/tests/graphData.ts
+++ b/net/browserless_agent/tests/graphData.ts
@@ -83,3 +83,23 @@ export const graphDataErrorResponse: GraphData = {
     },
   },
 };
+
+// Graph for testing api key from env
+export const graphDataApiKeyFromEnv: GraphData = {
+  version: graphDataLatestVersion,
+  nodes: {
+    start: {
+      agent: "browserlessAgent",
+      inputs: {
+        url: "https://example.com",
+      },
+    },
+    success: {
+      agent: "copyAgent",
+      inputs: {
+        result: ":start",
+      },
+      isResult: true,
+    },
+  },
+};

--- a/net/browserless_agent/tests/test_browserless_agent.ts
+++ b/net/browserless_agent/tests/test_browserless_agent.ts
@@ -92,7 +92,9 @@ const cleanupEnvironment = () => {
 test("test browserless content", async () => {
   setupEnvironment();
   try {
-    const result = await graphDataTestRunner(
+    const result = await graphDataTestRunner<{
+      result: string;
+    }>(
       __dirname,
       __filename,
       graphDataContent,
@@ -101,7 +103,7 @@ test("test browserless content", async () => {
       false,
     );
 
-    const resultData = (result as any).success.result;
+    const resultData = result.success?.result;
     assert.equal(resultData, mockContentHtml, "Expected success result");
   } finally {
     cleanupEnvironment();
@@ -111,7 +113,9 @@ test("test browserless content", async () => {
 test("test browserless text content", async () => {
   setupEnvironment();
   try {
-    const result = await graphDataTestRunner(
+    const result = await graphDataTestRunner<{
+      result: string;
+    }>(
       __dirname,
       __filename,
       graphDataTextContent,
@@ -120,7 +124,7 @@ test("test browserless text content", async () => {
       false,
     );
 
-    const resultData = (result as any).success.result;
+    const resultData = result.success?.result;
     assert.equal(resultData, mockBody.data[0].results[0].text, "Expected success result");
   } finally {
     cleanupEnvironment();
@@ -149,7 +153,15 @@ test("test browserless error response", async () => {
   setupEnvironment();
 
   try {
-    const result = await graphDataTestRunner(
+    const result = await graphDataTestRunner<{
+      result: {
+        onError: {
+          message: string;
+          status?: number;
+          error: any;
+        };
+      };
+    }>(
       __dirname,
       __filename,
       graphDataErrorResponse,
@@ -158,8 +170,8 @@ test("test browserless error response", async () => {
       false,
     );
 
-    const resultData = (result as any).error.result;
-    assert.ok(resultData.onError, "Expected error result");
+    const resultData = result.error?.result;
+    assert.ok(resultData?.onError, "Expected error result");
   } finally {
     cleanupEnvironment();
   }
@@ -168,7 +180,9 @@ test("test browserless error response", async () => {
 test("test browserless api key from env", async () => {
   setupEnvironment();
   try {
-    const result = await graphDataTestRunner(
+    const result = await graphDataTestRunner<{
+      result: string;
+    }>(
       __dirname,
       __filename,
       graphDataApiKeyFromEnv,
@@ -177,7 +191,7 @@ test("test browserless api key from env", async () => {
       false,
     );
 
-    const resultData = (result as any).success.result;
+    const resultData = result?.success?.result;
     assert.equal(resultData, mockContentHtml, "Expected success result");
   } finally {
     cleanupEnvironment();

--- a/net/browserless_agent/tests/test_browserless_agent.ts
+++ b/net/browserless_agent/tests/test_browserless_agent.ts
@@ -2,7 +2,7 @@ import { graphDataTestRunner } from "@receptron/test_utils";
 import browserlessAgentInfo from "../src/browserless_agent";
 import { copyAgent } from "@graphai/vanilla";
 
-import { graphDataContent, graphDataNoToken, graphDataErrorResponse, graphDataTextContent } from "./graphData";
+import { graphDataContent, graphDataNoToken, graphDataErrorResponse, graphDataTextContent, graphDataApiKeyFromEnv } from "./graphData";
 
 import test from "node:test";
 import assert from "node:assert";
@@ -160,6 +160,25 @@ test("test browserless error response", async () => {
 
     const resultData = (result as any).error.result;
     assert.ok(resultData.onError, "Expected error result");
+  } finally {
+    cleanupEnvironment();
+  }
+});
+
+test("test browserless api key from env", async () => {
+  setupEnvironment();
+  try {
+    const result = await graphDataTestRunner(
+      __dirname,
+      __filename,
+      graphDataApiKeyFromEnv,
+      { browserlessAgent: browserlessAgentInfo, copyAgent } as any,
+      () => {},
+      false,
+    );
+
+    const resultData = (result as any).success.result;
+    assert.equal(resultData, mockContentHtml, "Expected success result");
   } finally {
     cleanupEnvironment();
   }


### PR DESCRIPTION
This PR fixes an issue in the API key handling for the browserless agent. 

### Changes:
-  Fixed a bug where the API key could not be retrieved even if it was set in the environment variables.
-  Added related tests.
- Fix type cast