### PR TITLE
Add brave search agent

### DIFF
--- a/net/brave_search_agent/README.md
+++ b/net/brave_search_agent/README.md
@@ -1,0 +1,79 @@
+
+# @graphai/brave_search_agent for GraphAI
+
+An agent that uses the Brave Search API
+
+### Install
+
+```sh
+yarn add @graphai/brave_search_agent
+```
+
+
+### Usage
+
+```typescript
+import { GraphAI } from "graphai";
+import { braveSearchAgent } from "@graphai/brave_search_agent";
+
+const agents = { braveSearchAgent };
+
+const graph = new GraphAI(graph_data, agents);
+const result = await graph.run();
+```
+
+### Agents description
+- braveSearchAgent - An agent that uses the Brave Search API. https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
+
+### Input/Output/Params Schema & samples
+ - [braveSearchAgent](https://github.com/receptron/graphai-agents/blob/main/docs/agentDocs/net/braveSearchAgent.md)
+
+### Input/Params example
+ - braveSearchAgent
+
+```typescript
+{
+  "inputs": {
+    "query": "GraphAI framework"
+  },
+  "params": {}
+}
+```
+
+
+```typescript
+{
+  "inputs": {
+    "query": "GraphAI vs TensorFlow",
+    "search_args": {
+      "country": "JP",
+      "language": "ja"
+    }
+  },
+  "params": {}
+}
+```
+
+
+```typescript
+{
+  "inputs": {
+    "query": "GraphAI tutorials"
+  },
+  "params": {
+    "debug": true
+  }
+}
+```
+
+
+### Environment Variables
+ - braveSearchAgent
+   - BRAVE_SEARCH_API_TOKEN
+
+
+
+
+
+
+

--- a/net/brave_search_agent/eslint.config.mjs
+++ b/net/brave_search_agent/eslint.config.mjs
@@ -1,0 +1,9 @@
+import eslintBase from "../../config/eslint.config.base.mjs";
+
+export default [
+  {
+    files: ["{src,test}/**/*.{js,ts,yaml,yml,json}"],
+  },
+  {},
+  ...eslintBase,
+];

--- a/net/brave_search_agent/lib/brave_search_agent.d.ts
+++ b/net/brave_search_agent/lib/brave_search_agent.d.ts
@@ -1,0 +1,33 @@
+import { AgentFunction, AgentFunctionInfo, DefaultConfigData } from "graphai";
+interface BraveSearchInputs {
+    query: string;
+    search_args?: Record<string, any>;
+}
+interface BraveSearchParams {
+    apiKey?: string;
+    debug?: boolean;
+    throwError?: boolean;
+    search_args?: Record<string, any>;
+}
+interface BraveSearchResult {
+    title: string;
+    link: string;
+    snippet: string;
+}
+type BraveSearchResponse = {
+    items: BraveSearchResult[];
+} | {
+    onError: {
+        message: string;
+        error: string;
+        status?: number;
+    };
+} | {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    params: Record<string, any>;
+};
+export declare const braveSearchAgent: AgentFunction<BraveSearchParams, BraveSearchResponse, BraveSearchInputs, DefaultConfigData>;
+declare const braveSearchAgentInfo: AgentFunctionInfo;
+export default braveSearchAgentInfo;

--- a/net/brave_search_agent/lib/brave_search_agent.js
+++ b/net/brave_search_agent/lib/brave_search_agent.js
@@ -1,0 +1,221 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.braveSearchAgent = void 0;
+const graphai_1 = require("graphai");
+const getBraveSearchToken = (params, config) => {
+    if (params?.apiKey) {
+        return params.apiKey;
+    }
+    if (config?.apiKey) {
+        return config.apiKey;
+    }
+    return typeof process !== "undefined" ? process?.env?.BRAVE_SEARCH_API_TOKEN : null;
+};
+const braveSearchAgent = async ({ namedInputs, params, config, }) => {
+    const { query, search_args } = namedInputs;
+    (0, graphai_1.assert)(!!query, "braveSearchAgent: query is required! set inputs: { query: 'your search query' }");
+    const throwError = params?.throwError ?? false;
+    const _search_args = search_args ?? params?.search_args ?? {};
+    const braveSearchToken = getBraveSearchToken(params, config);
+    // Check if API token is provided
+    if (!braveSearchToken) {
+        const errorMessage = "Brave Search API token is required. Please set the BRAVE_SEARCH_API_TOKEN environment variable.";
+        throw new Error(errorMessage);
+    }
+    const baseUrl = "https://api.search.brave.com/res/v1/web/search";
+    const searchParams = {
+        ..._search_args,
+        q: query,
+    };
+    // Return request information in debug mode
+    if (params?.debug) {
+        return {
+            url: baseUrl,
+            method: "GET",
+            headers: {
+                "X-Subscription-Token": braveSearchToken,
+                Accept: "application/json",
+            },
+            params: searchParams,
+        };
+    }
+    // Build URL with query parameters
+    const url = new URL(baseUrl);
+    Object.entries(searchParams).forEach(([key, value]) => {
+        url.searchParams.append(key, String(value));
+    });
+    const fetchOptions = {
+        method: "GET",
+        headers: new Headers({
+            "X-Subscription-Token": braveSearchToken,
+            Accept: "application/json",
+        }),
+    };
+    try {
+        const response = await fetch(url.toString(), fetchOptions);
+        if (!response.ok) {
+            const status = response.status;
+            const error = await response.text();
+            if (throwError) {
+                throw new Error(`Brave Search HTTP error: ${status}`);
+            }
+            return {
+                items: [],
+                onError: {
+                    message: `Brave Search HTTP error: ${status}`,
+                    status,
+                    error,
+                },
+            };
+        }
+        const jsonResponse = await response.json();
+        const webResults = jsonResponse.web?.results || [];
+        const formattedResults = webResults.map((item) => ({
+            title: item.title,
+            link: item.url,
+            snippet: item.description,
+        }));
+        return {
+            items: formattedResults,
+        };
+    }
+    catch (error) {
+        if (throwError) {
+            throw error;
+        }
+        return {
+            onError: {
+                message: error instanceof Error ? error.message : "Unknown error occurred",
+                error: error instanceof Error ? error.toString() : String(error),
+            },
+        };
+    }
+};
+exports.braveSearchAgent = braveSearchAgent;
+const braveSearchAgentInfo = {
+    name: "braveSearchAgent",
+    agent: exports.braveSearchAgent,
+    mock: exports.braveSearchAgent,
+    params: {
+        type: "object",
+        properties: {
+            apiKey: {
+                type: "string",
+                description: "Brave Search API key",
+            },
+            debug: {
+                type: "boolean",
+                description: "Enable debug mode",
+            },
+            throwError: {
+                type: "boolean",
+                description: "Throw error if the request fails",
+            },
+            search_args: {
+                type: "object",
+                description: "Additional search parameters to pass to the Brave Search API. See https://api-dashboard.search.brave.com/app/documentation/web-search/query",
+            },
+        },
+    },
+    inputs: {
+        type: "object",
+        properties: {
+            query: {
+                type: "string",
+                description: "The search query to send to Brave Search",
+            },
+            search_args: {
+                type: "object",
+                description: "Additional search parameters to pass to the Brave Search API. See https://api-dashboard.search.brave.com/app/documentation/web-search/query",
+            },
+        },
+        required: ["query"],
+    },
+    output: {
+        type: "object",
+        properties: {
+            items: {
+                type: "array",
+                items: {
+                    type: "object",
+                    properties: {
+                        title: {
+                            type: "string",
+                            description: "The title of the search result",
+                        },
+                        link: {
+                            type: "string",
+                            description: "The URL of the search result",
+                        },
+                        snippet: {
+                            type: "string",
+                            description: "A snippet of text from the search result",
+                        },
+                    },
+                },
+            },
+        },
+    },
+    samples: [
+        {
+            inputs: {
+                query: "GraphAI framework",
+            },
+            params: {},
+            result: {
+                items: [
+                    {
+                        title: "GraphAI: A Modern AI Framework",
+                        link: "https://example.com/graphai",
+                        snippet: "GraphAI is a modern framework for building AI applications with a focus on graph-based architectures.",
+                    },
+                    {
+                        title: "Getting Started with GraphAI",
+                        link: "https://example.com/graphai/docs",
+                        snippet: "Learn how to get started with GraphAI, the powerful framework for AI development.",
+                    },
+                ],
+            },
+        },
+        {
+            inputs: {
+                query: "GraphAI vs TensorFlow",
+                search_args: {
+                    country: "JP",
+                    language: "ja",
+                },
+            },
+            params: {},
+            result: {
+                items: [
+                    {
+                        title: "GraphAIとは何か？",
+                        link: "https://example.com/ja/graphai",
+                        snippet: "GraphAIの概要を説明します。",
+                    },
+                ],
+            },
+        },
+        {
+            inputs: {
+                query: "GraphAI tutorials",
+            },
+            params: {
+                debug: true,
+            },
+            result: {
+                url: "https://api.search.brave.com/res/v1/web/search",
+                method: "GET",
+                headers: { "X-Subscription-Token": "your-api-key", Accept: "application/json" },
+                params: { q: "GraphAI tutorials", extra_snippets: true },
+            },
+        },
+    ],
+    description: "An agent that uses the Brave Search API. https://api-dashboard.search.brave.com/app/documentation/web-search/get-started",
+    category: ["net"],
+    author: "kawamataryo",
+    repository: "https://github.com/receptron/graphai-agents",
+    license: "MIT",
+    environmentVariables: ["BRAVE_SEARCH_API_TOKEN"],
+};
+exports.default = braveSearchAgentInfo;

--- a/net/brave_search_agent/lib/index.d.ts
+++ b/net/brave_search_agent/lib/index.d.ts
@@ -1,0 +1,2 @@
+import braveSearchAgent from "./brave_search_agent";
+export { braveSearchAgent };

--- a/net/brave_search_agent/lib/index.js
+++ b/net/brave_search_agent/lib/index.js
@@ -1,0 +1,8 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.braveSearchAgent = void 0;
+const brave_search_agent_1 = __importDefault(require("./brave_search_agent"));
+exports.braveSearchAgent = brave_search_agent_1.default;

--- a/net/brave_search_agent/package.json
+++ b/net/brave_search_agent/package.json
@@ -20,7 +20,7 @@
     "type": "git",
     "url": "git+https://github.com/receptron/graphai-agents.git"
   },
-  "author": "",
+  "author": "kawamataryo",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/receptron/graphai-agents/issues"

--- a/net/brave_search_agent/package.json
+++ b/net/brave_search_agent/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@graphai/brave_search_agent",
+  "version": "0.0.1",
+  "description": "An agent that uses the Brave Search API",
+  "main": "lib/index.js",
+  "files": [
+    "./lib"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "eslint": "eslint src --fix",
+    "format": "prettier --write '{src,tests}/**/*.ts'",
+    "doc": "npx agentdoc",
+    "test_run": "node --test --require ts-node/register ./tests/run_*.ts",
+    "test": "node --test  -r tsconfig-paths/register --require ts-node/register ./tests/test_*.ts",
+    "ci": "yarn run format && yarn run eslint && yarn run test && yarn run build",
+    "sample": "npx ts-node ./samples/search.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/graphai-agents.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/receptron/graphai-agents/issues"
+  },
+  "homepage": "https://github.com/receptron/graphai-agents/blob/main/net/brave_search_agent/README.md",
+  "devDependencies": {
+    "undici": "^6.21.1"
+  },
+  "types": "./lib/index.d.ts",
+  "directories": {
+    "lib": "lib"
+  }
+}

--- a/net/brave_search_agent/samples/search.ts
+++ b/net/brave_search_agent/samples/search.ts
@@ -8,7 +8,7 @@ const graph_data: GraphData = {
   version: 0.5,
   nodes: {
     input: {
-      value: { content: "Graph AI" },
+      value: { content: "GraphAI" },
     },
     braveSearch: {
       agent: "braveSearchAgent",

--- a/net/brave_search_agent/samples/search.ts
+++ b/net/brave_search_agent/samples/search.ts
@@ -1,0 +1,37 @@
+import "dotenv/config";
+
+import { GraphData } from "graphai";
+import { graphDataTestRunner } from "@receptron/test_utils";
+import braveSearchAgentInfo from "../src/brave_search_agent";
+
+const graph_data: GraphData = {
+  version: 0.5,
+  nodes: {
+    input: {
+      value: { content: "Graph AI" },
+    },
+    braveSearch: {
+      agent: "braveSearchAgent",
+      inputs: {
+        query: ":input.content",
+        search_args: {
+          country: "JP",
+          search_lang: "jp",
+          count: 3,
+        },
+      },
+    },
+    result: {
+      agent: "copyAgent",
+      inputs: { result: ":braveSearch.items" },
+      isResult: true,
+    },
+  },
+};
+
+export const main = async () => {
+  const result = await graphDataTestRunner(__dirname + "/../", __filename, graph_data, { braveSearchAgent: braveSearchAgentInfo });
+  console.log(result["result"]);
+};
+
+main();

--- a/net/brave_search_agent/src/brave_search_agent.ts
+++ b/net/brave_search_agent/src/brave_search_agent.ts
@@ -1,3 +1,4 @@
+import { GraphAIOnError } from "@graphai/agent_utils";
 import { AgentFunction, AgentFunctionInfo, assert, DefaultConfigData } from "graphai";
 
 interface BraveSearchInputs {
@@ -22,13 +23,7 @@ type BraveSearchResponse =
   | {
       items: BraveSearchResult[];
     }
-  | {
-      onError: {
-        message: string;
-        error: string;
-        status?: number;
-      };
-    }
+  | GraphAIOnError<string>
   | {
       url: string;
       method: string;

--- a/net/brave_search_agent/src/brave_search_agent.ts
+++ b/net/brave_search_agent/src/brave_search_agent.ts
@@ -1,0 +1,278 @@
+import { AgentFunction, AgentFunctionInfo, assert, DefaultConfigData } from "graphai";
+
+interface BraveSearchInputs {
+  query: string;
+  search_args?: Record<string, any>;
+}
+
+interface BraveSearchParams {
+  apiKey?: string;
+  debug?: boolean;
+  throwError?: boolean;
+  search_args?: Record<string, any>;
+}
+
+interface BraveSearchResult {
+  title: string;
+  link: string;
+  snippet: string;
+}
+
+type BraveSearchResponse =
+  | {
+      items: BraveSearchResult[];
+    }
+  | {
+      onError: {
+        message: string;
+        error: string;
+        status?: number;
+      };
+    }
+  | {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      params: Record<string, any>;
+    };
+
+const getBraveSearchToken = (params: BraveSearchParams, config?: DefaultConfigData) => {
+  if (params?.apiKey) {
+    return params.apiKey;
+  }
+  if (config?.apiKey) {
+    return config.apiKey;
+  }
+  return typeof process !== "undefined" ? process?.env?.BRAVE_SEARCH_API_TOKEN : null;
+};
+
+export const braveSearchAgent: AgentFunction<BraveSearchParams, BraveSearchResponse, BraveSearchInputs, DefaultConfigData> = async ({
+  namedInputs,
+  params,
+  config,
+}) => {
+  const { query, search_args } = namedInputs;
+
+  assert(!!query, "braveSearchAgent: query is required! set inputs: { query: 'your search query' }");
+
+  const throwError = params?.throwError ?? false;
+  const _search_args = search_args ?? params?.search_args ?? {};
+
+  const braveSearchToken = getBraveSearchToken(params, config);
+
+  // Check if API token is provided
+  if (!braveSearchToken) {
+    const errorMessage = "Brave Search API token is required. Please set the BRAVE_SEARCH_API_TOKEN environment variable.";
+    throw new Error(errorMessage);
+  }
+
+  const baseUrl = "https://api.search.brave.com/res/v1/web/search";
+  const searchParams = {
+    ..._search_args,
+    q: query,
+  };
+
+  // Return request information in debug mode
+  if (params?.debug) {
+    return {
+      url: baseUrl,
+      method: "GET",
+      headers: {
+        "X-Subscription-Token": braveSearchToken,
+        Accept: "application/json",
+      },
+      params: searchParams,
+    };
+  }
+
+  // Build URL with query parameters
+  const url = new URL(baseUrl);
+  Object.entries(searchParams).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
+
+  const fetchOptions: RequestInit = {
+    method: "GET",
+    headers: new Headers({
+      "X-Subscription-Token": braveSearchToken,
+      Accept: "application/json",
+    }),
+  };
+
+  try {
+    const response = await fetch(url.toString(), fetchOptions);
+
+    if (!response.ok) {
+      const status = response.status;
+      const error = await response.text();
+
+      if (throwError) {
+        throw new Error(`Brave Search HTTP error: ${status}`);
+      }
+
+      return {
+        items: [],
+        onError: {
+          message: `Brave Search HTTP error: ${status}`,
+          status,
+          error,
+        },
+      };
+    }
+
+    const jsonResponse = await response.json();
+    const webResults = jsonResponse.web?.results || [];
+
+    const formattedResults = webResults.map((item: any) => ({
+      title: item.title,
+      link: item.url,
+      snippet: item.description,
+    }));
+
+    return {
+      items: formattedResults,
+    };
+  } catch (error) {
+    if (throwError) {
+      throw error;
+    }
+
+    return {
+      onError: {
+        message: error instanceof Error ? error.message : "Unknown error occurred",
+        error: error instanceof Error ? error.toString() : String(error),
+      },
+    };
+  }
+};
+
+const braveSearchAgentInfo: AgentFunctionInfo = {
+  name: "braveSearchAgent",
+  agent: braveSearchAgent,
+  mock: braveSearchAgent,
+  params: {
+    type: "object",
+    properties: {
+      apiKey: {
+        type: "string",
+        description: "Brave Search API key",
+      },
+      debug: {
+        type: "boolean",
+        description: "Enable debug mode",
+      },
+      throwError: {
+        type: "boolean",
+        description: "Throw error if the request fails",
+      },
+      search_args: {
+        type: "object",
+        description:
+          "Additional search parameters to pass to the Brave Search API. See https://api-dashboard.search.brave.com/app/documentation/web-search/query",
+      },
+    },
+  },
+  inputs: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "The search query to send to Brave Search",
+      },
+      search_args: {
+        type: "object",
+        description:
+          "Additional search parameters to pass to the Brave Search API. See https://api-dashboard.search.brave.com/app/documentation/web-search/query",
+      },
+    },
+    required: ["query"],
+  },
+  output: {
+    type: "object",
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: {
+              type: "string",
+              description: "The title of the search result",
+            },
+            link: {
+              type: "string",
+              description: "The URL of the search result",
+            },
+            snippet: {
+              type: "string",
+              description: "A snippet of text from the search result",
+            },
+          },
+        },
+      },
+    },
+  },
+  samples: [
+    {
+      inputs: {
+        query: "GraphAI framework",
+      },
+      params: {},
+      result: {
+        items: [
+          {
+            title: "GraphAI: A Modern AI Framework",
+            link: "https://example.com/graphai",
+            snippet: "GraphAI is a modern framework for building AI applications with a focus on graph-based architectures.",
+          },
+          {
+            title: "Getting Started with GraphAI",
+            link: "https://example.com/graphai/docs",
+            snippet: "Learn how to get started with GraphAI, the powerful framework for AI development.",
+          },
+        ],
+      },
+    },
+    {
+      inputs: {
+        query: "GraphAI vs TensorFlow",
+        search_args: {
+          country: "JP",
+          language: "ja",
+        },
+      },
+      params: {},
+      result: {
+        items: [
+          {
+            title: "GraphAIとは何か？",
+            link: "https://example.com/ja/graphai",
+            snippet: "GraphAIの概要を説明します。",
+          },
+        ],
+      },
+    },
+    {
+      inputs: {
+        query: "GraphAI tutorials",
+      },
+      params: {
+        debug: true,
+      },
+      result: {
+        url: "https://api.search.brave.com/res/v1/web/search",
+        method: "GET",
+        headers: { "X-Subscription-Token": "your-api-key", Accept: "application/json" },
+        params: { q: "GraphAI tutorials", extra_snippets: true },
+      },
+    },
+  ],
+  description: "An agent that uses the Brave Search API. https://api-dashboard.search.brave.com/app/documentation/web-search/get-started",
+  category: ["net"],
+  author: "kawamataryo",
+  repository: "https://github.com/receptron/graphai-agents",
+  license: "MIT",
+  environmentVariables: ["BRAVE_SEARCH_API_TOKEN"],
+};
+
+export default braveSearchAgentInfo;

--- a/net/brave_search_agent/src/index.ts
+++ b/net/brave_search_agent/src/index.ts
@@ -1,0 +1,3 @@
+import braveSearchAgent from "./brave_search_agent";
+
+export { braveSearchAgent };

--- a/net/brave_search_agent/tests/graphData.ts
+++ b/net/brave_search_agent/tests/graphData.ts
@@ -1,0 +1,84 @@
+import { GraphData, graphDataLatestVersion } from "graphai";
+
+// Graph for testing search
+export const graphDataSearch: GraphData = {
+  version: graphDataLatestVersion,
+  nodes: {
+    start: {
+      agent: "braveSearchAgent",
+      inputs: {
+        query: "graphai",
+      },
+    },
+    success: {
+      agent: "copyAgent",
+      inputs: {
+        items: ":start.items",
+      },
+      isResult: true,
+    },
+  },
+};
+
+// Graph for testing missing API token
+export const graphDataNoToken: GraphData = {
+  version: graphDataLatestVersion,
+  nodes: {
+    start: {
+      agent: "braveSearchAgent",
+      inputs: {
+        query: "graphai",
+      },
+    },
+    success: {
+      agent: "copyAgent",
+      inputs: {
+        result: ":start",
+      },
+      isResult: true,
+    },
+  },
+};
+
+// Graph for testing error response handling
+export const graphDataErrorResponse: GraphData = {
+  version: graphDataLatestVersion,
+  nodes: {
+    start: {
+      agent: "braveSearchAgent",
+      inputs: {
+        query: "error",
+      },
+      params: {
+        throwError: false,
+      },
+    },
+    error: {
+      agent: "copyAgent",
+      inputs: {
+        result: ":start",
+      },
+      isResult: true,
+    },
+  },
+};
+
+// Graph for testing api key from env
+export const graphDataApiKeyFromEnv: GraphData = {
+  version: graphDataLatestVersion,
+  nodes: {
+    start: {
+      agent: "braveSearchAgent",
+      inputs: {
+        query: "graphai",
+      },
+    },
+    success: {
+      agent: "copyAgent",
+      inputs: {
+        items: ":start.items",
+      },
+      isResult: true,
+    },
+  },
+};

--- a/net/brave_search_agent/tests/test_brave_search_agent.ts
+++ b/net/brave_search_agent/tests/test_brave_search_agent.ts
@@ -1,0 +1,152 @@
+import { graphDataTestRunner } from "@receptron/test_utils";
+import braveSearchAgentInfo from "../src/brave_search_agent";
+import { copyAgent } from "@graphai/vanilla";
+
+import { graphDataSearch, graphDataNoToken, graphDataErrorResponse, graphDataApiKeyFromEnv } from "./graphData";
+
+import test from "node:test";
+import assert from "node:assert";
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from "undici";
+
+// Mock response data
+const mockSearchResults = {
+  web: {
+    results: [
+      {
+        title: "GraphAI: A Modern AI Framework",
+        url: "https://example.com/graphai",
+        description: "GraphAI is a modern framework for building AI applications.",
+      },
+      {
+        title: "Getting Started with GraphAI",
+        url: "https://example.com/graphai/docs",
+        description: "Learn how to get started with GraphAI.",
+      },
+    ],
+  },
+};
+
+// Save the original global dispatcher
+const originalDispatcher = getGlobalDispatcher();
+
+const mockAgent = new MockAgent();
+mockAgent.disableNetConnect();
+
+const setupEnvironment = () => {
+  process.env.BRAVE_SEARCH_API_TOKEN = "test_token";
+
+  setGlobalDispatcher(mockAgent);
+
+  const mockPool = mockAgent.get("https://api.search.brave.com");
+
+  // Mock the search endpoint for regular search queries
+  mockPool
+    .intercept({
+      path: (path) => path.startsWith("/res/v1/web/search") && path.includes("q=graphai"),
+      method: "GET",
+      headers: {
+        "x-subscription-token": "test_token",
+        accept: "application/json",
+      },
+    })
+    .reply(200, mockSearchResults, {
+      headers: { "content-type": "application/json" },
+    });
+
+  // Mock error responses
+  mockPool
+    .intercept({
+      path: (path) => path.startsWith("/res/v1/web/search") && path.includes("q=error"),
+      method: "GET",
+      headers: {
+        "x-subscription-token": "test_token",
+        accept: "application/json",
+      },
+    })
+    .reply(429, "Too many requests");
+};
+
+const cleanupEnvironment = () => {
+  delete process.env.BRAVE_SEARCH_API_TOKEN;
+  setGlobalDispatcher(originalDispatcher);
+};
+
+test("test brave search", async () => {
+  setupEnvironment();
+  try {
+    const result = await graphDataTestRunner<{
+      items: Array<{
+        title: string;
+        link: string;
+        snippet: string;
+      }>;
+    }>(__dirname, __filename, graphDataSearch, { braveSearchAgent: braveSearchAgentInfo, copyAgent }, () => {}, false);
+
+    const resultData = result.success?.items;
+    console.log(resultData);
+    assert.ok(resultData, "Expected results array");
+    assert.equal(resultData.length, 2, "Expected 2 search results");
+    assert.equal(resultData[0].title, mockSearchResults.web.results[0].title, "Expected matching title");
+    assert.equal(resultData[0].link, mockSearchResults.web.results[0].url, "Expected matching URL");
+  } finally {
+    cleanupEnvironment();
+  }
+});
+
+test("test brave search without token", async () => {
+  setupEnvironment();
+  delete process.env.BRAVE_SEARCH_API_TOKEN;
+
+  try {
+    await graphDataTestRunner(__dirname, __filename, graphDataNoToken, { braveSearchAgent: braveSearchAgentInfo, copyAgent }, () => {}, false);
+    assert.fail("Expected error to be thrown");
+  } catch (error) {
+    if (error instanceof Error) {
+      assert.ok(error.message.includes("API token is required"), "Expected error message about missing API token");
+    } else {
+      // Fail the test for unexpected errors
+      assert.fail(`Unexpected error: ${error}`);
+    }
+  } finally {
+    setGlobalDispatcher(originalDispatcher);
+  }
+});
+
+test("test brave search error response", async () => {
+  setupEnvironment();
+
+  try {
+    const result = await graphDataTestRunner<{
+      result: {
+        onError: {
+          message: string;
+          status?: number;
+          error: string;
+        };
+      };
+    }>(__dirname, __filename, graphDataErrorResponse, { braveSearchAgent: braveSearchAgentInfo, copyAgent }, () => {}, false);
+
+    const resultData = result.error?.result.onError;
+    assert.ok(resultData, "Expected error result");
+  } finally {
+    cleanupEnvironment();
+  }
+});
+
+test.only("test brave search api key from env", async () => {
+  setupEnvironment();
+  try {
+    const result = await graphDataTestRunner<{
+      items: Array<{
+        title: string;
+        link: string;
+        snippet: string;
+      }>;
+    }>(__dirname, __filename, graphDataApiKeyFromEnv, { braveSearchAgent: braveSearchAgentInfo, copyAgent }, () => {}, false);
+
+    const resultData = result.success?.items;
+    console.log(resultData);
+  } finally {
+    cleanupEnvironment();
+  }
+});

--- a/net/brave_search_agent/tsconfig.json
+++ b/net/brave_search_agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./", 
+    "rootDir": "./src/",
+    "outDir": "./lib",
+    "paths": {
+      "@/*": ["./src/*"],
+      "~/*": ["./tests/*"],
+    }
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@graphai/agent_filters": "0.2.2",
     "@graphai/vanilla": "^1.0.0",
     "@graphai/vanilla_node_agents": "^0.2.7",
+    "@graphai/agent_utils": "^0.0.9",
     "@receptron/agentdoc": "^0.0.10",
     "@receptron/test_utils": "^1.0.1",
     "@rollup/plugin-commonjs": "^28.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,11 @@
   resolved "https://registry.yarnpkg.com/@graphai/agent_utils/-/agent_utils-0.0.3.tgz#95dff049247c4ad0da20443062654fb1826061f7"
   integrity sha512-dybbO54rI9E1XfNaHhxLT9xES7G9KC2mXyDYaKvvcDF3bSF6/870CzQb3AOxqzy6WadkKPO+oFye85RM8uNaHg==
 
+"@graphai/agent_utils@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@graphai/agent_utils/-/agent_utils-0.0.9.tgz#a293a245e8f3b89abca118ee3608d0ea51ed69a3"
+  integrity sha512-hH7kLQ0UMI2vqcm1z6NGCX2veVNxzdF4DwSYk0Nvhxqv4Y9Joqv9vXvLWq+wH/009bTiBFR2qmVYFW8xvsAUlA==
+
 "@graphai/llm_utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@graphai/llm_utils/-/llm_utils-0.2.0.tgz#03de706c5dc91f4650fa540bb75a15646dc79d88"


### PR DESCRIPTION
## Overview

This PR adds a new agent, `brave_search_agent`, to GraphAI that leverages the [Brave Search API](https://api-dashboard.search.brave.com/app/documentation/web-search/get-started). This agent enables performing web searches with Brave's search engine directly from GraphAI applications.

## Key Features

- Web search functionality with customizable parameters

## Background

Integrating search capabilities into AI applications is essential for retrieving up-to-date information from the web.
Additionally, Brave Search is user-friendly as it allows up to 2,000 requests per month for free.


## Reference

This implementation follows the langchain Brave Search:
https://python.langchain.com/docs/integrations/tools/brave_search/

## Test

You can test it with the following script after getting the [Brave Search API key](https://api-dashboard.search.brave.com/app/keys).

```
export BRAVE_SEARCH_API_TOKEN=your_api_key
npm run sample
```

![CleanShot 2025-03-15 at 14 59 29@2x](https://github.com/user-attachments/assets/836f058e-4632-4022-ae37-da54a27826e5)
