### PR TITLE
Use agent-utils and suppressError

### DIFF
--- a/net/brave_search_agent/package.json
+++ b/net/brave_search_agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphai/brave_search_agent",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "description": "An agent that uses the Brave Search API",
   "main": "lib/index.js",
   "files": [

--- a/net/brave_search_agent/tests/graphData.ts
+++ b/net/brave_search_agent/tests/graphData.ts
@@ -50,7 +50,7 @@ export const graphDataErrorResponse: GraphData = {
         query: "error",
       },
       params: {
-        throwError: false,
+        supressError: true,
       },
     },
     error: {

--- a/net/browserless_agent/package.json
+++ b/net/browserless_agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphai/browserless_agent",
-  "version": "0.0.3",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "files": [

--- a/net/browserless_agent/tests/graphData.ts
+++ b/net/browserless_agent/tests/graphData.ts
@@ -71,7 +71,7 @@ export const graphDataErrorResponse: GraphData = {
         url: "https://error.example.com",
       },
       params: {
-        throwError: false,
+        supressError: true,
       },
     },
     error: {


### PR DESCRIPTION
 We have made the following changes to the browserless_agent and brave_search_agent:

-  Utilized the types from agent-utils
-  Implemented support for suppressError
-  Updated the version to 2.0.0